### PR TITLE
bump bcprov, 1.58 is vulnerable. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     // The production code uses the SLF4J logging API at compile time
     compile 'org.slf4j:slf4j-api:1.7.21'
-    compile 'org.bouncycastle:bcprov-jdk15on:1.58'
+    compile 'org.bouncycastle:bcprov-jdk15on:1.63'
     compile 'commons-io:commons-io:2.5'
     compile 'commons-cli:commons-cli:1.3.1'
 


### PR DESCRIPTION
Our Nexus IQ instance flagged this as vulnerable:
http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-1000613
http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-1000180

